### PR TITLE
Create gce-all-active-lb.conf

### DIFF
--- a/gce-all-active-lb.conf
+++ b/gce-all-active-lb.conf
@@ -1,0 +1,43 @@
+#Primary load balancing config file for the all-active NGINX Plus deployment on Google Compute Engine (GCE)
+
+upstream upstream_app_pool {
+    server 10.128.0.2;
+    server 10.128.0.3;
+    zone   upstream-apps 64k;
+    sticky cookie GCPPersist expires=300;
+}
+
+server {
+    listen      80 default_server;
+    server_name _;
+    error_page	404	/404.html;
+    error_page	500 502 503 504	/50x.html;
+    error_log	  /var/log/nginx/lb-error.log notice;
+
+    location /50x.html {
+        root	/usr/share/nginx/html;
+    }
+
+    #enable shared memory for monitoring upstream servers
+    status_zone upstream-apps;
+
+    location / {
+        proxy_pass         http://upstream_app_pool/;
+        add_header         'X-Forwarded-For' '$proxy_add_x_forwarded_for';
+        add_header         'X-Forwarded-Proto' '$scheme';
+        health_check;
+        proxy_http_version 1.1;
+    }
+
+    location /images {
+        root /usr/share/nginx;
+    }
+
+    location ~ /favicon.ico {
+        root /usr/share/nginx/images; 
+    }
+
+    location ~ /status-old.html {
+        root /usr/share/nginx/html; 
+    }
+}


### PR DESCRIPTION
Making gce-all-active-lb.conf file available at https://www.nginx.com/resources/conf/ as well as in GitHub repository NGINX-Demos/gce-nginx-plus-deployment-guide-files/etc_nginx_conf.d/